### PR TITLE
Fix exclude option to properly match root-level directories

### DIFF
--- a/lib/calltally/config.rb
+++ b/lib/calltally/config.rb
@@ -8,7 +8,7 @@ module Calltally
     DEFAULTS = {
       "profile"              => "auto",  # auto|rails|default
       "dirs"                 => %w[.],
-      "exclude"              => %w[spec test vendor node_modules tmp log .git .bundle],
+      "exclude"              => %w[vendor node_modules tmp log .git .bundle],
       "top"                  => 100,
       "verbose"              => false,
       "mode"                 => "pairs", # pairs|methods|receivers

--- a/lib/calltally/scanner.rb
+++ b/lib/calltally/scanner.rb
@@ -84,7 +84,9 @@ module Calltally
 
     def excluded?(path)
       rel = path.sub(@base_dir + "/", "")
-      @config["exclude"].any? { |ex| rel.include?("/#{ex}/") || File.basename(rel).start_with?("#{ex}.") }
+      @config["exclude"].any? do |ex|
+        rel == ex || rel.start_with?("#{ex}/", "#{ex}.") || rel.include?("/#{ex}/")
+      end
     end
 
     def read_source(path)

--- a/test/samples/exclude_test/bar.rb
+++ b/test/samples/exclude_test/bar.rb
@@ -1,0 +1,14 @@
+class Bar
+  def process
+    data = fetch_data
+    data.each { |item| handle(item) }
+  end
+
+  def fetch_data
+    ["a", "b", "c"]
+  end
+
+  def handle(item)
+    item.upcase
+  end
+end

--- a/test/samples/exclude_test/foo.rb
+++ b/test/samples/exclude_test/foo.rb
@@ -1,0 +1,10 @@
+class Foo
+  def foo_method
+    puts "foo"
+    bar_method
+  end
+
+  def bar_method
+    [1, 2, 3].map { |x| x * 2 }
+  end
+end

--- a/test/test_exclude_option.rb
+++ b/test/test_exclude_option.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "open3"
+
+class TestExcludeOption < Minitest::Test
+  def run_calltally(path, options = "")
+    cmd = "ruby -I lib exe/calltally #{path} #{options}"
+    stdout, stderr, _ = Open3.capture3(cmd)
+    stderr.empty? ? stdout : "#{stdout}#{stderr}"
+  end
+
+  def test_with_exclude_removes_directory
+    output = run_calltally("test/samples", "-n 10 -x exclude_test --include-nil-receiver")
+
+    refute_match(/bar_method/, output, "bar_method should be excluded")
+    refute_match(/fetch_data/, output, "fetch_data should be excluded")
+    refute_match(/handle/, output, "handle should be excluded")
+
+    assert_match(/times|positive|zero|tap|upcase|fetch|merge/, output, "methods from other files should be shown")
+  end
+
+  def test_exclude_adds_to_defaults
+    output_without = run_calltally("test/samples", "-v")
+    output_with = run_calltally("test/samples", "-x exclude_test -v")
+
+    assert_match(/Scan targets: 4 files/, output_without, "should scan 4 files normally")
+    assert_match(/Scan targets: 2 files/, output_with, "should scan 2 files when excluded")
+  end
+
+  def test_multiple_excludes
+    output = run_calltally("test/samples", "-n 10 -x exclude_test,advanced_variables --include-nil-receiver")
+
+    refute_match(/bar_method/, output, "exclude_test/bar.rb methods should be excluded")
+    refute_match(/fetch_data/, output, "exclude_test/bar.rb methods should be excluded")
+    refute_match(/positive\?/, output, "advanced_variables.rb methods should be excluded")
+
+    assert_match(/User\.find|User\.where|Post\.published/, output, "basic_calls.rb methods should be shown")
+  end
+end


### PR DESCRIPTION
  ## Summary
  - Fixed `exclude` option not excluding root-level directories (e.g., `spec/`, `test/`)
  - Removed `test`/`spec` from default excludes to enable test code analysis

