### PR TITLE
Fix Rails profile detection to check for gem "rails" declaration

### DIFF
--- a/lib/calltally/config.rb
+++ b/lib/calltally/config.rb
@@ -51,7 +51,7 @@ module Calltally
       return desired unless desired == "auto"
 
       gemfile_path = File.join(base_dir, "Gemfile")
-      if File.file?(gemfile_path) && File.read(gemfile_path).include?("rails")
+      if File.file?(gemfile_path) && File.read(gemfile_path).match?(/^\s*gem\s+["']rails["']/)
         "rails"
       else
         "default"


### PR DESCRIPTION
Changed from simple string contains to regex matching to avoid false positives 
with Rails framework repo and Rails-related gems.