### PR TITLE
Drop Ruby 3.2 support and update dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,6 @@ jobs:
           - '4.0'
           - '3.4'
           - '3.3'
-          - '3.2'
 
     steps:
       - uses: actions/checkout@v4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ GEM
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
-    prism (1.7.0)
+    prism (1.9.0)
     psych (5.3.1)
       date
       stringio
@@ -45,4 +45,4 @@ DEPENDENCIES
   rake (~> 13.0)
 
 BUNDLED WITH
-   2.7.2
+  4.0.10

--- a/calltally.gemspec
+++ b/calltally.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
                       "refactoring decisions, and identifying heavily-used APIs."
   spec.homepage = "https://github.com/nsgc/calltally"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.2.0"
+  spec.required_ruby_version = ">= 3.3.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/nsgc/calltally.git"
@@ -33,9 +33,10 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  # Dependencies for compatibility across Ruby versions
-  spec.add_dependency "prism", ">= 1.0"  # Needed for Ruby 3.2, built-in for 3.3+
-  spec.add_dependency "csv", ">= 3.0"    # No longer bundled with Ruby 3.4+
+  # Ruby 3.3 ships prism 0.19; we need 1.x API
+  spec.add_dependency "prism", ">= 1.0"
+  # csv is no longer bundled with Ruby 3.4+
+  spec.add_dependency "csv", ">= 3.0"
 
   spec.add_development_dependency "rake", "~> 13.0"
 end

--- a/lib/calltally/formatter.rb
+++ b/lib/calltally/formatter.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
 require "json"
-begin
-  require "csv"
-rescue LoadError
-  # CSV is optional for Ruby 3.4+
-end
+require "csv"
 
 module Calltally
   module Formatter

--- a/lib/calltally/prism_visitor.rb
+++ b/lib/calltally/prism_visitor.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
-begin
-  require "prism"
-rescue LoadError
-  warn "[calltally] prism not found. Install 'prism' gem or use Ruby 3.3+."
-  raise
-end
+require "prism"
 
 module Calltally
   class PrismVisitor < ::Prism::Visitor


### PR DESCRIPTION
- Ruby 3.2 reached end-of-life (2026-03-31)
- Bump required_ruby_version to >= 3.3.0
- Remove Ruby 3.2 from CI matrix
- Update prism to 1.9.0 for visitor performance improvement on large codebases
- Update Bundler to 4.0.10
- Drop LoadError guards that were only needed for Ruby 3.2 compatibility
